### PR TITLE
(feat) refactor authContext user and add friend/other user profile feature

### DIFF
--- a/frontend-v2/src/App.tsx
+++ b/frontend-v2/src/App.tsx
@@ -1,9 +1,11 @@
 import { MantineProvider } from '@mantine/core';
+import { Notifications } from '@mantine/notifications';
 import { FC, ReactNode } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import MyRoutes from './routes';
 import './styles/global.css';
 import { myTheme } from './styles/mantineTheme';
+import { AuthContextProvider } from './context/AuthContext';
 
 export type FCWithLayout<P = object> = FC<P> & {
   getLayout?: (page: ReactNode) => JSX.Element;
@@ -12,9 +14,12 @@ export type FCWithLayout<P = object> = FC<P> & {
 const App: FC = () => {
   return (
     <BrowserRouter>
-      <MantineProvider withGlobalStyles withNormalizeCSS theme={myTheme}>
-        <MyRoutes />
-      </MantineProvider>
+      <AuthContextProvider>
+        <MantineProvider withGlobalStyles withNormalizeCSS theme={myTheme}>
+          <Notifications />
+          <MyRoutes />
+        </MantineProvider>
+      </AuthContextProvider>
     </BrowserRouter>
   );
 };

--- a/frontend-v2/src/components/Navbar/index.tsx
+++ b/frontend-v2/src/components/Navbar/index.tsx
@@ -36,7 +36,7 @@ const Navbar: FC = () => {
                 key={route.name.toLowerCase()}
                 className={`${styles['page-nav-link']} ${isActive(route) ? styles['active'] : ''}`}
               >
-                <Link to={route.path}>
+                <Link to={route.navPath || route.path}>
                   <Text weight='bold'>{route.name}</Text>
                 </Link>
                 <Space w='xl' />

--- a/frontend-v2/src/components/NavbarAvatar/index.tsx
+++ b/frontend-v2/src/components/NavbarAvatar/index.tsx
@@ -18,7 +18,7 @@ const NavbarAvatar: FC = () => {
         <Flex className={styles['nav-avatar']} justify='space-between' align='center'>
           <HoverCard width={260} shadow='md' openDelay={100} closeDelay={100}>
             <HoverCard.Target>
-              <Link to='/profile'>
+              <Link to='/profile/me'>
                 <Image
                   radius='50%'
                   width={50}
@@ -36,7 +36,7 @@ const NavbarAvatar: FC = () => {
                   label='Profile'
                   description={user.email}
                   icon={<IconUser size='1rem' stroke={1.5} />}
-                  onClick={() => navigate('/profile')}
+                  onClick={() => navigate('/profile/me')}
                 ></NavLink>
                 <Button color='red' onClick={logout} my={10}>
                   Log Out

--- a/frontend-v2/src/components/Profile/ProfileCard/index.tsx
+++ b/frontend-v2/src/components/Profile/ProfileCard/index.tsx
@@ -1,34 +1,88 @@
-import { Avatar, Button, Card, Flex, Modal, TextInput, Title, Tooltip } from '@mantine/core';
+import {
+  Avatar,
+  Button,
+  Card,
+  Flex,
+  LoadingOverlay,
+  Modal,
+  TextInput,
+  Title,
+  Tooltip,
+} from '@mantine/core';
 import { IconAt, IconUser, IconUserEdit } from '@tabler/icons-react';
 import { useDisclosure } from '@mantine/hooks';
-import { FC } from 'react';
+import { useParams } from 'react-router-dom';
+import { FC, useEffect, useState } from 'react';
 import ProfileUserForm from '../ProfileUserForm';
 import { useAuthContext } from '../../../hooks/useAuthContext';
+import { IUser } from '../../../context/AuthContext';
+import api from '../../../services/api';
+import { AxiosError } from 'axios';
+import { alert, success } from '../../Notifications';
 
 const ProfileCard: FC = () => {
+  const { userId } = useParams();
   const { user } = useAuthContext();
   const [opened, { open, close }] = useDisclosure(false);
+  const [userData, setUserData] = useState<IUser | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isLoggedUser, setIsLoggedUser] = useState(false);
+  const notificationTitle = 'Profile';
+
+  useEffect(() => {
+    if (userId === 'me' || userId == user?.id) {
+      setUserData(user);
+      setIsLoggedUser(true);
+      if (userId == user?.id) history.replaceState(null, '', '/profile/me');
+    } else if (!userData) {
+      setIsLoading(true);
+      api
+        .get(`/users/${userId}`)
+        .then(({ data }) => {
+          setUserData(data);
+          success('Successfully fetched user data', notificationTitle);
+        })
+        .catch((err) => {
+          if (err instanceof AxiosError) {
+            alert(err.response?.data.message, notificationTitle);
+          } else {
+            alert('Error occured while fetchin user data', notificationTitle);
+          }
+        })
+        .finally(() => setIsLoading(false));
+    }
+  }, [user]);
 
   return (
-    <Card shadow='xl' px={20} p={16} withBorder>
+    <Card shadow='xl' px={20} p={16} withBorder style={{ position: 'relative' }}>
+      <LoadingOverlay
+        loaderProps={{ color: 'secondary', variant: 'bars' }}
+        overlayOpacity={0.2}
+        visible={isLoading}
+        overlayBlur={1}
+      />
       <Flex align='center' justify='space-between' mb={12}>
         <Title color='white' order={2}>
           Profile
         </Title>
 
-        <Modal opened={opened} onClose={close} title='Edit profile'>
-          <ProfileUserForm />
-        </Modal>
+        {isLoggedUser && (
+          <>
+            <Modal opened={opened} onClose={close} title='Edit profile'>
+              <ProfileUserForm />
+            </Modal>
 
-        <Tooltip color='lightBlack' withArrow label='Edit profile' position='right'>
-          <Button variant='outline' color='secondary' radius='50%' p={8} onClick={open}>
-            <IconUserEdit width={18} height={18} radius='50%' />
-          </Button>
-        </Tooltip>
+            <Tooltip color='lightBlack' withArrow label='Edit profile' position='right'>
+              <Button variant='outline' color='secondary' radius='50%' p={8} onClick={open}>
+                <IconUserEdit width={18} height={18} radius='50%' />
+              </Button>
+            </Tooltip>
+          </>
+        )}
       </Flex>
       <Flex justify='space-between' align='center'>
         <Avatar
-          src={user?.avatarUrl || '/images/cat-pirate.jpg'}
+          src={userData?.avatarUrl || '/images/cat-pirate.jpg'}
           size='xl'
           radius='50%'
           style={{ border: '2px solid #F46036' }}
@@ -37,14 +91,14 @@ const ProfileCard: FC = () => {
           <TextInput
             disabled
             label='username'
-            value={user?.username}
+            value={userData?.username || ''}
             icon={<IconUser size='0.8rem' />}
           />
           <TextInput
             disabled
             my={4}
             label='email'
-            value={user?.email}
+            value={userData?.email || ''}
             icon={<IconAt size='0.8rem' />}
           />
         </Flex>

--- a/frontend-v2/src/context/AuthContext.tsx
+++ b/frontend-v2/src/context/AuthContext.tsx
@@ -1,11 +1,11 @@
 import {
   createContext,
-  Dispatch,
   FC,
   PropsWithChildren,
   useCallback,
   useEffect,
   useReducer,
+  useState,
 } from 'react';
 
 export type IUser = {
@@ -23,53 +23,27 @@ export type IState = {
   user?: IUser;
 };
 
-type IAuthContext = IState & {
-  dispatch: Dispatch<IAction>;
-  updateUser: (user: IUser) => void;
-};
-
-type IAction = {
-  type: string;
-  payload?: any;
+type IAuthContext = {
+  user: IUser | null;
+  updateUser: (user: IUser | null) => void;
 };
 
 export const AuthContext = createContext<IAuthContext | null>(null);
 
-export const authReducer = (state: IState, action: IAction) => {
-  switch (action.type) {
-    case 'LOGIN':
-      return { user: action.payload };
-    case 'LOGOUT':
-      return { user: null };
-    case 'UPDATE':
-      return { user: action.payload };
-    default:
-      return state;
-  }
-};
-
 export const AuthContextProvider: FC<PropsWithChildren> = ({ children }) => {
-  const [state, dispatch] = useReducer(authReducer, { user: null });
-
-  useEffect(() => {
-    const user = localStorage.getItem('user');
-    if (user) {
-      dispatch({ type: 'LOGIN', payload: JSON.parse(user) });
-    }
-  }, []);
+  const [user, setUser] = useState<IUser | null>(() => {
+    const storageUser = localStorage.getItem('user');
+    if (storageUser) return JSON.parse(storageUser) as IUser;
+    return null;
+  });
 
   const updateUser = useCallback(
-    (user: IUser) => {
-      localStorage.setItem('user', JSON.stringify(user));
-
-      dispatch({ type: 'UPDATE', payload: user });
+    (updatedUser: IUser | null) => {
+      localStorage.setItem('user', JSON.stringify(updatedUser));
+      setUser(updatedUser);
     },
-    [state],
+    [user],
   );
 
-  return (
-    <AuthContext.Provider value={{ ...state, updateUser, dispatch }}>
-      {children}
-    </AuthContext.Provider>
-  );
+  return <AuthContext.Provider value={{ user, updateUser }}>{children}</AuthContext.Provider>;
 };

--- a/frontend-v2/src/hooks/useLogin.ts
+++ b/frontend-v2/src/hooks/useLogin.ts
@@ -15,7 +15,7 @@ export type TwoFactorAuthenticationDto = {
 };
 
 export const useLogin = () => {
-  const { dispatch } = useAuthContext();
+  const { updateUser } = useAuthContext();
   const navigate = useNavigate();
   const location = useLocation();
   const from = location.state?.from?.pathname || '/';
@@ -85,8 +85,7 @@ export const useLogin = () => {
   };
 
   const saveUser = async (user: IUser) => {
-    localStorage.setItem('user', JSON.stringify(user));
-    dispatch({ type: 'LOGIN', payload: user });
+    updateUser(user);
     success('Your user was logged in successfully!');
     navigate(from, { replace: true });
   };

--- a/frontend-v2/src/hooks/useLogout.ts
+++ b/frontend-v2/src/hooks/useLogout.ts
@@ -3,7 +3,7 @@ import api from '../services/api';
 import { useAuthContext } from './useAuthContext';
 
 export const useLogout = () => {
-  const { dispatch } = useAuthContext();
+  const { updateUser } = useAuthContext();
 
   const logout = async () => {
     // Remove http-only cookies
@@ -15,11 +15,8 @@ export const useLogout = () => {
       }
     }
 
-    // Remove user from local storage
+    updateUser(null);
     localStorage.removeItem('user');
-
-    // Dispatch logout action
-    dispatch({ type: 'LOGOUT' });
   };
 
   return { logout };

--- a/frontend-v2/src/hooks/useSignUp.ts
+++ b/frontend-v2/src/hooks/useSignUp.ts
@@ -13,7 +13,7 @@ export type CreateUserDto = {
 export const useSignUp = () => {
   const [error, setError] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const { dispatch } = useAuthContext();
+  const { updateUser } = useAuthContext();
 
   const signUp = async (createUserDto: CreateUserDto) => {
     setIsLoading(true);
@@ -24,7 +24,7 @@ export const useSignUp = () => {
       const json = await response.data;
 
       localStorage.setItem('user', JSON.stringify(json));
-      dispatch({ type: 'LOGIN', payload: json });
+      updateUser(json);
       setIsLoading(false);
     } catch (err) {
       if (err instanceof AxiosError) {

--- a/frontend-v2/src/index.tsx
+++ b/frontend-v2/src/index.tsx
@@ -1,21 +1,13 @@
-import { MantineProvider } from '@mantine/core';
-import { Notifications } from '@mantine/notifications';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { AuthContextProvider } from './context/AuthContext';
 import reportWebVitals from './reportWebVitals';
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
 root.render(
   <React.StrictMode>
-    <AuthContextProvider>
-      <MantineProvider withNormalizeCSS withGlobalStyles>
-        <Notifications />
-        <App />
-      </MantineProvider>
-    </AuthContextProvider>
+    <App />
   </React.StrictMode>,
 );
 

--- a/frontend-v2/src/pages/Profile/index.tsx
+++ b/frontend-v2/src/pages/Profile/index.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@mantine/core';
-import { FCWithLayout } from '../App';
-import ProfileCard from '../components/Profile/ProfileCard';
+import { FCWithLayout } from '../../App';
+import ProfileCard from '../../components/Profile/ProfileCard';
 
 const Profile: FCWithLayout = () => {
   return (

--- a/frontend-v2/src/routes/routes.config.ts
+++ b/frontend-v2/src/routes/routes.config.ts
@@ -12,6 +12,7 @@ export interface IRoutesConfig {
   isPrivate?: boolean; // route needs user authenticated
   showOnNavbar?: boolean; // show this route on navbar
   noLayout?: boolean; // the page does not have a default layout (navbar, image background and footer)
+  navPath?: string; // sometimes navbar path might be different from routes (e.g. when you route params)
 }
 
 const routesConfig: IRoutesConfig[] = [
@@ -29,10 +30,11 @@ const routesConfig: IRoutesConfig[] = [
   },
   {
     name: 'Profile',
-    path: '/profile',
+    path: '/profile/:userId',
     component: Profile,
     isPrivate: true,
     showOnNavbar: true,
+    navPath: '/profile/me',
   },
   {
     name: 'Login',


### PR DESCRIPTION
- Providers set on App.tsx
- Profile view for user logged and other users
- AuthContext user set as state - removed the reducer
  - reason: when accessing a route path directly on browser the reducer set user as null so you get redirected to login or home
  - user as a state you can pre-define the user as the user that is on localStorage and it's a simpler approach